### PR TITLE
Add patch as a dependency

### DIFF
--- a/installation-app/rpm/headless-keyboard.spec
+++ b/installation-app/rpm/headless-keyboard.spec
@@ -22,6 +22,7 @@ Source0:    %{name}-%{version}.tar.bz2
 Requires:   sailfishsilica-qt5 >= 0.10.9
 Requires:   pygobject2
 Requires:   dbus-python
+Requires:   patch
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)


### PR DESCRIPTION
Required for installation and uninstallation.

Currently, installing the rpm without `patch` somehow succeeds: the patch doesn't get applied, but the app shows in the app drawer and runs.

However, uninstallation without `patch` causes an error and prevents the removal from succeeding.

Making this change should fix both issues.
 